### PR TITLE
Update zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/graphix)
 [![Downloads](https://static.pepy.tech/badge/graphix)](https://pepy.tech/project/graphix)
 [![Unitary Foundation](https://img.shields.io/badge/Supported%20By-Unitary%20Foundation-brightgreen.svg)](https://unitary.foundation/)
-[![DOI](https://zenodo.org/badge/573466585.svg)](https://zenodo.org/badge/latestdoi/573466585)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.18503266.svg)](https://doi.org/10.5281/zenodo.18503266)
 [![CI](https://github.com/TeamGraphix/graphix/actions/workflows/ci.yml/badge.svg)](https://github.com/TeamGraphix/graphix/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/TeamGraphix/graphix/graph/badge.svg?token=E41MLUTYXU)](https://codecov.io/gh/TeamGraphix/graphix)
 [![Documentation Status](https://readthedocs.org/projects/graphix/badge/?version=latest)](https://graphix.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
I noticed that the Zenodo badge is broken, so this may a good PR to fix it. Also, since we are modifying the README, I'd be inclined to remove the link to `swiflow`: I don't know what the status is, but the CI is broken.