### PR TITLE
Remove circular dependency on `graphix-qasm-parser`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -65,6 +65,8 @@ def tests_extra(session: Session) -> None:
 def tests_all(session: Session) -> None:
     """Run the test suite with all dependencies."""
     session.install(".[dev,extra]")
+    # This dependency is added here to avoid circular dependencies
+    session.install("graphix-qasm-parser>=0.1.1")
     run_pytest(session, doctest_modules=True, mpl=True)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,6 @@ dev = [
     "qiskit>=1.0",
     "qiskit_qasm3_import",
     "qiskit-aer",
-    "openqasm-parser>=3.1.0",
-    "graphix-qasm-parser>=0.1.1",
 ]
 doc = [
     "furo",


### PR DESCRIPTION
The circular dependency makes `dependabot` fail.
https://github.com/TeamGraphix/graphix/network/updates/1352648692
